### PR TITLE
Fix no std

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ name = "fxhash"
 path = "bench.rs"
 
 [dependencies]
-byteorder = "1.0.0"
+byteorder = { version = "1.0.0", default-features = false }
 hashmap_core = { version = "0.1.5", optional = true }
 
 [dev-dependencies]
@@ -28,5 +28,5 @@ fnv = "1.0.5"
 
 [features]
 default = ["std"]
-std = []
+std = ["byteorder/std"]
 core = ["hashmap_core"]


### PR DESCRIPTION
It still depended on byteorder with the std feature, so this did not compile on targets actually without `std`.